### PR TITLE
Fixed bug where stateSem is undefined

### DIFF
--- a/roverprocess/RoverProcess.py
+++ b/roverprocess/RoverProcess.py
@@ -80,12 +80,12 @@ class RoverProcess(Process):
 
 	def run(self):
 		""" This is method is what runs in a new process.
-		First the receiver thread is started, then the setup method is
-		called, and finally the loop method is run in an infinite while loop.
+		First the setup method is called, then the receiver thread is started,
+		and finally the loop method is run in an infinite while loop.
 		"""
-		self.receiver.start()
 		try:
 			self.setup(self._args)
+			self.receiver.start()
 
 			while not self.quit:
 				try:


### PR DESCRIPTION
Pull request is overkill for this, but the workflow must hold!
Fixed a bug where a race condition happened an processes tried to subscribe before StateManager finished its setup method.
RoverProcess now runs the setup method first and then starts the ReceiverThread.
Credit to @ausshir and @irene000 for figuring it out.

Closes issue #75 .

