### PR TITLE
Move data routing to RoverServer

### DIFF
--- a/main.py
+++ b/main.py
@@ -86,7 +86,7 @@ def init_rover_classes(modulesList):
 def main():
 	init_logging()
 
-	modulesList = init_modulesList("DriveProcess", "WebServer", "USBServer")
+	modulesList = init_modulesList("DriveProcess", "WebServer", "USBServer", "ExampleProcess")
 
 	rover_classes = init_rover_classes(modulesList)
 

--- a/main.py
+++ b/main.py
@@ -86,7 +86,7 @@ def init_rover_classes(modulesList):
 def main():
 	init_logging()
 
-	modulesList = init_modulesList("DriveProcess", "WebServer", "USBServer", "ExampleProcess")
+	modulesList = init_modulesList("DriveProcess",  "USBServer", "ExampleProcess")
 
 	rover_classes = init_rover_classes(modulesList)
 

--- a/roverprocess/ExampleProcess.py
+++ b/roverprocess/ExampleProcess.py
@@ -16,6 +16,7 @@ from .RoverProcess import RoverProcess
 # Any libraries you need can be imported here. You almost always need time!
 import time
 from pyvesc import BlinkLed
+import pyvesc
 
 
 class ExampleProcess(RoverProcess):
@@ -35,7 +36,7 @@ class ExampleProcess(RoverProcess):
 		# which is a list of messages it is currently subscribed to.
 		# You can read from this list, but please do not modify it,
 		# as that will mess things up. Use subscribe() and unsubscribe().
-		for key in ["Test", "respondTrue", "heartbeat"]:
+		for key in ["Test", "respondTrue", "heartbeat", "ExampleSendMessage"]:
 			self.subscribe(key)
 		self.someVariable = 42
 
@@ -59,6 +60,9 @@ class ExampleProcess(RoverProcess):
 
 		if message.key == 'Test':
 			self.log("got: " + str(message.data))
+		elif message.key == 'ExampleSendMessage':
+			# message.data should be a PyVESC ExampleSendMessage
+			self.log("got: "+ str(message.data.string))
 
 	# This runs once at the end when the program shuts down.
 	# You can use this to do something like stop motors, clean up open files, etc.

--- a/roverprocess/RoverServer.py
+++ b/roverprocess/RoverServer.py
@@ -50,6 +50,23 @@ class RoverServer(RoverProcess):
 		RoverProcess.__init__(self, downlink=kwargs["downlink"],
 				uplink=kwargs["uplink"])
 		self.workers = []
+		self.subscriberMap = {}
+
+	def messageTrigger(self, message):
+		if message.key in self.subscriberMap:
+			for device in self.subscriberMap[message.key]:
+				self.send_cmd(message, device)
+
+	def send_cmd(self, message, device):
+		""" Function for sending a message to a device.
+			Override this method to implement proper sending
+			of data over whatever standard you are using.
+
+			Args:
+				message: The rover message to send
+				device: The device instance to send it to.
+		"""
+		pass
 
 	def spawnThread(self, function, **kwargs):
 		"""Spawns a new thread with the given function.

--- a/roverprocess/RoverServer.py
+++ b/roverprocess/RoverServer.py
@@ -51,6 +51,7 @@ class RoverServer(RoverProcess):
 				uplink=kwargs["uplink"])
 		self.workers = []
 		self.subscriberMap = {}
+		self.semList = {}
 
 	def messageTrigger(self, message):
 		if message.key in self.subscriberMap:
@@ -67,6 +68,30 @@ class RoverServer(RoverProcess):
 				device: The device instance to send it to.
 		"""
 		pass
+
+	def read_cmd(self, device):
+		""" Function for reading messages from a device.
+			Override this method to implement proper sending
+			of data over whatever standard you are using.
+			
+			Args:
+				device: name of which device to read from.
+				in your overriden version, use this in a with statement.
+		"""
+		pass
+
+	def listenToDevice(self, **kwargs):
+		while not self.quit:
+			try:
+				msg = self.read_cmd(kwargs['port'])
+				if msg is not None:
+					self.log(msg[0], "DEBUG")
+					self.publish(msg[0], msg[1])
+			except:
+				# failed to open port
+				self.log("Read fail", "DEBUG")
+				pass
+			time.sleep(0.005)
 
 	def spawnThread(self, function, **kwargs):
 		"""Spawns a new thread with the given function.

--- a/roverprocess/RoverServer.py
+++ b/roverprocess/RoverServer.py
@@ -52,6 +52,7 @@ class RoverServer(RoverProcess):
 		self.workers = []
 		self.subscriberMap = {}
 		self.semList = {}
+		
 
 	def messageTrigger(self, message):
 		if message.key in self.subscriberMap:
@@ -111,6 +112,29 @@ class RoverServer(RoverProcess):
 		new_thread = RoverServer.WorkerThread(function, **kwargs)
 		self.workers.append(new_thread)
 		new_thread.start()
+	
+	def getSubscription(self, port):
+		pass
+	
+	
+	def reqSubscription(self, port):
+		""" Request susbscriptions from a device.
+
+		Subscribe to the message if we're not subscribed already.
+		Also store the device for later. Finally, spin up a thread
+		to listen for incomming messages from the device.
+		"""
+		s = self.getSubscription(port)
+		if not s:
+			return # failed to get a good packet, abort
+		if s not in self.subscriberMap:
+			self.subscriberMap[s] = []
+			self.subscribe(s)
+		self.subscriberMap[s].append(port.device)
+		self.DeviceList.append(port.device)
+		#self.semList[port.device] = BoundedSemaphore()
+		
+		self.spawnThread(self.listenToDevice, port=port.device)
 
 	def cleanup(self):
 		RoverProcess.cleanup(self)

--- a/roverprocess/RoverServer.py
+++ b/roverprocess/RoverServer.py
@@ -84,6 +84,7 @@ class RoverServer(RoverProcess):
 		""" Returns a device instance of a port name
 			Override this method to handle the particular
 			device communication standard you are using.
+
 			Args:
 				port (str): Path to a particular instance of a device
 		"""
@@ -139,13 +140,12 @@ class RoverServer(RoverProcess):
 
 	def reqSubscription(self, port):
 		""" Request susbscriptions from a device.
-
 		Subscribe to the message if we're not subscribed already.
 		Also store the device for later. Finally, spin up a thread
 		to listen for incomming messages from the device.
 
-			Args:
-				port (str): Path to a particular instance of a device
+		Args:
+			port (str): Path to a particular instance of a device
 		"""
 		with self.getDevice(port) as device:
 			s = self.getSubscription(device)

--- a/roverprocess/USBServer.py
+++ b/roverprocess/USBServer.py
@@ -54,16 +54,10 @@ class USBServer(RoverServer):
 			else:
 				return None
 
-	def reqSubscription(self, port):
-		""" Request susbscriptions from a device.
-
-		If we get an invalid response, try again up to 4 times.
-		Subscribe to the message if we're not subscribed already.
-		Also store the device for later. Finally, spin up a thread
-		to listen for incomming messages from the device.
-		"""
+	def getSubscription(self, port):
+		s = None
 		with serial.Serial(port.device, baudrate=BAUDRATE, timeout=0.5) as ser:
-			s = None
+			
 			errors = 0
 			while errors < 4: # try reading 4 times
 				try:
@@ -77,14 +71,6 @@ class USBServer(RoverServer):
 				except:
 					errors += 1 # got another bad packet
 					self.log("Got bad packet", "WARNING")
-			if not s:
-				return # failed to get a good packet, abort
-			if s not in self.subscriberMap:
-				self.subscriberMap[s] = []
-				self.subscribe(s)
-			self.subscriberMap[s].append(port.device)
-			self.DeviceList.append(port.device)
-			self.semList[port.device] = BoundedSemaphore()
-			ser.reset_input_buffer()
-			self.spawnThread(self.listenToDevice, port=port.device)
+				ser.reset_input_buffer()
+		return s
 

--- a/roverprocess/USBServer.py
+++ b/roverprocess/USBServer.py
@@ -5,7 +5,6 @@ import serial
 import time
 from ctypes import *
 from serial.threaded import *
-from  multiprocessing import BoundedSemaphore
 import pyvesc
 
 BAUDRATE = 115200
@@ -25,7 +24,6 @@ class USBServer(RoverServer):
 
 	def setup(self, args):
 		""" Initialize subscription maps and find what messages devices are susbribed to."""
-		self.DeviceList = []
 		ports = list_ports.comports()
 		for port in ports:
 			if port.device == '/dev/ttyS0' or port.device == '/dev/ttyAMA0':


### PR DESCRIPTION
Refactoring of USBServer and RoverServer to facilitate easier creation of communication routers.
Initially the plan was to make the StateManager a RoverServer as well, but upon looking at it closely, I think it is more trouble than it's worth, but feel free to try it yourself. I think it would be better to properly implement this abstraction in a future rewrite.

List of changes:
- RoverServer keeps track of what messages connected devices are subscribed to.
- RoverServer implements the messageTrigger method that forwards received messages to subscribed devices.
- RoverServer has a method for listening for messages from each device.
- USBServer now only implements the usb serial specific portion of the communication stack.


Closes issue #66 .

